### PR TITLE
Add new command to get repository tag

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -5,6 +5,7 @@ use Keboola\DeveloperPortal\Cli\Command\GetLoginCommand;
 use Keboola\DeveloperPortal\Cli\Command\GetRepository;
 use Keboola\DeveloperPortal\Cli\Command\UpdateAppPropertyCommand;
 use Keboola\DeveloperPortal\Cli\Command\UpdateAppRepositoryCommand;
+use Keboola\DeveloperPortal\Cli\Command\GetAppRepositoryTag;
 use Symfony\Component\Console\Application;
 
 define('ROOT_PATH', __DIR__ . '/../');
@@ -24,6 +25,7 @@ $application->addCommands([
     new GetLoginCommand(),
     new GetRepository(),
     new UpdateAppRepositoryCommand(),
-    new UpdateAppPropertyCommand()
+    new UpdateAppPropertyCommand(),
+    new GetAppRepositoryTag(),
 ]);
 $application->run();

--- a/src/Command/GetAppRepositoryTag.php
+++ b/src/Command/GetAppRepositoryTag.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DeveloperPortal\Cli\Command;
+
+use Keboola\DeveloperPortal\Cli\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GetAppRepositoryTag extends Command
+{
+    public const COMMAND_NAME = 'get-app-repository-tag';
+
+    protected function configure(): void
+    {
+        $this
+            ->setName(self::COMMAND_NAME)
+            ->addArgument('vendor', InputArgument::REQUIRED, 'Vendor ID')
+            ->addArgument('app', InputArgument::REQUIRED, 'App ID')
+            ->setDescription('Get app repository tag')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $client = $this->login();
+        $component = $client->getAppDetail($input->getArgument('vendor'), $input->getArgument('app'));
+        $output->writeln($component['repository']['tag'] ?? '');
+    }
+}

--- a/tests/Command/GetAppRepositoryTagTest.php
+++ b/tests/Command/GetAppRepositoryTagTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DeveloperPortal\Cli\Tests\Command;
+
+use Keboola\DeveloperPortal\Cli\Command\GetAppRepositoryTag;
+use Keboola\DeveloperPortal\Cli\Command\UpdateAppRepositoryCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class GetAppRepositoryTagTest extends TestCase
+{
+    public function testExecute(): void
+    {
+        $application = new Application();
+        $application->add(new GetAppRepositoryTag());
+        $application->add(new UpdateAppRepositoryCommand());
+
+        // update app repository
+        $updateAppRepositoryCmd = $application->find('update-app-repository');
+        $randomTag = rand(0, 10) . "." . rand(0, 10) . "." . rand(0, 10);
+        $updateAppRepositoryCmdTester = new CommandTester($updateAppRepositoryCmd);
+        $updateAppRepositoryCmdTester->execute([
+            'command'  => $updateAppRepositoryCmd->getName(),
+            'vendor' => getenv('KBC_DEVELOPERPORTAL_TEST_VENDOR'),
+            'app' => getenv('KBC_DEVELOPERPORTAL_TEST_APP'),
+            'tag' => $randomTag,
+        ]);
+        $this->assertEquals(0, $updateAppRepositoryCmdTester->getStatusCode());
+        $this->assertStringContainsString(
+            sprintf('"tag": "%s"', $randomTag),
+            $updateAppRepositoryCmdTester->getDisplay()
+        );
+
+        // get app repository tag
+        $command = $application->find(GetAppRepositoryTag::COMMAND_NAME);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'command'  => $command->getName(),
+            'vendor' => getenv('KBC_DEVELOPERPORTAL_TEST_VENDOR'),
+            'app' => getenv('KBC_DEVELOPERPORTAL_TEST_APP'),
+        ]);
+        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertEquals($randomTag, trim($commandTester->getDisplay()));
+    }
+}


### PR DESCRIPTION
Fixes: #22 

Changes:

- Add `get-app-repository-tag` command to get component's repository tag

---

To keep it consistent I added command as "app", to prevent confusion. We should rename all commands in other PR.